### PR TITLE
Specify flutter version 2.5.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,7 @@ publish_to: none
 
 environment:
   sdk: '>=2.10.0 <3.0.0'
+  flutter: 2.5.1
 dependencies:
   flutter:
     sdk: flutter


### PR DESCRIPTION
Specify flutter version 2.5.1

Maybe this is not desired. It did help to build it with Flutter 2.8.x, though.